### PR TITLE
Added GH Actions-based CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,192 @@
+name: GitHub CI
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: 'bash -Eeuo pipefail -x {0}'
+
+jobs:
+  generate-matrix:
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix-alpine: ${{ steps.set-matrix.outputs.matrix-alpine }}
+      matrix-ubuntu: ${{ steps.set-matrix.outputs.matrix-ubuntu }}
+      matrix-redhat: ${{ steps.set-matrix.outputs.matrix-redhat }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: set-matrix
+        id: set-matrix
+        run: |
+          case "$GITHUB_EVENT_NAME" in
+            pull_request|push)
+              # use a small subset of modules to test against
+              COMMON_MODULES="base image-filter njs otel perl xslt"
+              ADD_MODULES="geoip"
+            ;;
+            workflow_dispatch)
+              # use all modules to test against
+              COMMON_MODULES="base auth-spnego brotli encrypted-session fips-check geoip2 headers-more image-filter lua ndk njs opentracing otel passenger perl rtmp set-misc subs-filter xslt"
+              ADD_MODULES="geoip"
+            ;;
+          esac
+
+          for os in alpine ubuntu redhat; do
+            M=$COMMON_MODULES
+            if [ "$os" != "redhat" ]; then
+              M="$M $ADD_MODULES"
+            fi
+            jq -nRr '"matrix-" + $os +"=" + ( { include: [ $ARGS.positional[] | {module: . } ] } | tojson)' --arg os $os --args $M  >> $GITHUB_OUTPUT
+          done
+
+  alpine:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.generate-matrix.outputs.matrix-alpine)}}
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup Alpine Linux
+        uses: jirutka/setup-alpine@v1
+        with:
+          branch: v3.20
+          packages: >
+            abuild
+            build-base
+            coreutils
+            curl
+            findutils
+            git
+            make
+            xz
+
+      - name: Figure out we're base or module
+        shell: alpine.sh {0}
+        run: |
+          module=""
+          case ${{ matrix.module }} in
+            base)
+            ;;
+            *)
+              module="module-"
+            ;;
+          esac
+          echo MODULE=$module >> $GITHUB_ENV
+
+      - name: Create build depends for ${{ matrix.module }}
+        shell: alpine.sh {0}
+        working-directory: alpine
+        run: |
+          make abuild-${MODULE}${{ matrix.module }}
+
+      - name: Install build depends for ${{ matrix.module }}
+        shell: alpine.sh --root {0}
+        working-directory: alpine
+        run: |
+          apk add $(. ./abuild-${MODULE}${{ matrix.module }}/APKBUILD; echo $makedepends;)
+
+      - name: Build ${{ matrix.module }}
+        shell: alpine.sh {0}
+        working-directory: alpine
+        run: |
+          make ${MODULE}${{ matrix.module }}
+
+  ubuntu:
+    runs-on: ubuntu-latest
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.generate-matrix.outputs.matrix-ubuntu)}}
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup Ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+            curl \
+            devscripts \
+            equivs \
+            git \
+            libxml2-utils \
+            lsb-release \
+            xsltproc
+
+      - name: Figure out we're base or module
+        run: |
+          module=""
+          case ${{ matrix.module }} in
+            base)
+            ;;
+            *)
+              module="module-"
+            ;;
+          esac
+          echo MODULE=$module >> $GITHUB_ENV
+
+      - name: Create and install build depends for ${{ matrix.module }} and build it
+        working-directory: debian
+        run: |
+          NGINX_VERSION=$(make --eval 'nv:; @echo $(BASE_VERSION)' nv)
+          make rules-${MODULE}${{ matrix.module }}
+          sudo mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" \
+            debuild-${MODULE}${{matrix.module}}/nginx-${NGINX_VERSION}/debian/control;
+          make ${MODULE}${{ matrix.module }}
+
+  redhat:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    container: almalinux:9
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.generate-matrix.outputs.matrix-redhat)}}
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup AlmaLinux
+        run: |
+          dnf makecache
+          dnf install -y \
+            g++ \
+            gcc \
+            git \
+            epel-release \
+            libxslt \
+            make \
+            rpm-build \
+            which \
+            xz \
+            'dnf-command(config-manager)'
+          dnf config-manager --set-enabled crb
+
+      - name: Figure out we're base or module
+        run: |
+          module=""
+          target=""
+          case ${{ matrix.module }} in
+            base)
+              target="base"
+            ;;
+            *)
+              module="-module-${{ matrix.module}}"
+              target="${module##-}"
+            ;;
+          esac
+          echo MODULE=$module >> $GITHUB_ENV
+          echo TARGET=$target >> $GITHUB_ENV
+
+      - name: Create and install build depends for ${{ matrix.module }} and build it
+        working-directory: rpm/SPECS
+        run: |
+          make nginx${MODULE}.spec
+          dnf -y install $(rpmspec -P ./nginx${MODULE}.spec | grep BuildRequires | cut -d: -f2- | xargs)
+          make ${TARGET}


### PR DESCRIPTION
This is probably not the final version we'd like to have here for the following reasons:
- it's ugly
- it does not cover all supported distros
- it does not cover all support arches - amd64, but not aarch64 (and we probably need debian/arm32v5, too...)
- it's probably way too many jobs and we should test "nginx modules + njs + otel" and "all modules" for each distro/arch
- do we really need schedule?

The current results are available at:
 - "pull request" / "push" : https://github.com/thresheek/pkg-oss/actions/runs/10712504478
 - "schedule" / "workflow_dispatch": https://github.com/thresheek/pkg-oss/actions/runs/10725651712