### PR TITLE
Various fixes for modules after recent bumps

### DIFF
--- a/alpine/Makefile.module-lua
+++ b/alpine/Makefile.module-lua
@@ -46,7 +46,8 @@ MODULE_DEPENDS_lua=$(NDK_DEPENDENCY_TAG)
 
 define MODULE_PREBUILD_lua
 	cd ../luajit2-$(LUAJIT2_VERSION) \&\& \
-	DESTDIR=`pwd` CFLAGS="-fPIC" make $$_make_opts install
+	CFLAGS="-fPIC" make $$_make_opts \&\& \
+	DESTDIR=`pwd` make $$_make_opts install
 endef
 export MODULE_PREBUILD_lua
 

--- a/contrib/src/thrift/0002-Fixed-build-with-GCC-4.8.5-on-RHEL-7.patch
+++ b/contrib/src/thrift/0002-Fixed-build-with-GCC-4.8.5-on-RHEL-7.patch
@@ -1,27 +1,14 @@
-From 7fd0aace135c794e2a791913a4e09412208e88c3 Mon Sep 17 00:00:00 2001
+From 25c75dcc1d911c3b97231e22fffa94da7bccb2bd Mon Sep 17 00:00:00 2001
 From: Konstantin Pavlov <thresh@nginx.com>
 Date: Wed, 22 Nov 2023 13:46:29 -0800
-Subject: [PATCH 2/2] Fixed build with GCC 4.8.5 on RHEL 7.
+Subject: [PATCH] Fixed build with GCC 4.8.5 on RHEL 7.
 
 ---
- lib/cpp/src/thrift/numeric_cast.h                | 1 +
  lib/cpp/src/thrift/transport/TBufferTransports.h | 1 +
- 2 files changed, 2 insertions(+)
+ 1 file changed, 1 insertion(+)
 
-diff --git a/lib/cpp/src/thrift/numeric_cast.h b/lib/cpp/src/thrift/numeric_cast.h
-index d7063dbc6..8775121a0 100644
---- a/lib/cpp/src/thrift/numeric_cast.h
-+++ b/lib/cpp/src/thrift/numeric_cast.h
-@@ -22,6 +22,7 @@
- 
- #include <limits>
- #include <stdexcept>
-+#include <typeinfo>
- 
- #if defined(_MSC_VER)
- // avoid compiler warnings and errors in MSVC if max is defined as a macro
 diff --git a/lib/cpp/src/thrift/transport/TBufferTransports.h b/lib/cpp/src/thrift/transport/TBufferTransports.h
-index f72d8f6bf..f8d23bf11 100644
+index 8518800a4..e74143243 100644
 --- a/lib/cpp/src/thrift/transport/TBufferTransports.h
 +++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
 @@ -23,6 +23,7 @@
@@ -33,5 +20,5 @@ index f72d8f6bf..f8d23bf11 100644
  #include <thrift/transport/TTransport.h>
  #include <thrift/transport/TVirtualTransport.h>
 -- 
-2.39.3 (Apple Git-145)
+2.46.1
 

--- a/debian/Makefile.module-lua
+++ b/debian/Makefile.module-lua
@@ -53,7 +53,8 @@ export MODULE_DEFINITIONS_lua
 
 define MODULE_PREBUILD_lua
 	cd $$(BUILDDIR_nginx)/extra/luajit2-$(LUAJIT2_VERSION) \&\& \
-	DESTDIR="$$(BUILDDIR_nginx)/extra/luajit2-$(LUAJIT2_VERSION)" CFLAGS="-fPIC" $$(MAKE) -j$$(NUMJOBS) install
+	$$(MAKE) -j$$(NUMJOBS) \&\& \
+	DESTDIR="$$(BUILDDIR_nginx)/extra/luajit2-$(LUAJIT2_VERSION)" $$(MAKE) install
 	mv $$(BUILDDIR_nginx)/extra/luajit2-$(LUAJIT2_VERSION)/usr/bin/luajit $$(BUILDDIR_nginx)/extra/luajit2-$(LUAJIT2_VERSION)/usr/bin/nginx-luajit
 	mv $$(BUILDDIR_nginx)/extra/luajit2-$(LUAJIT2_VERSION)/usr/share/man/man1/luajit.1 $$(BUILDDIR_nginx)/extra/luajit2-$(LUAJIT2_VERSION)/usr/share/man/man1/nginx-luajit.1
 endef

--- a/rpm/SPECS/Makefile
+++ b/rpm/SPECS/Makefile
@@ -338,6 +338,11 @@ check-compat-%:
 			nginx-module-$${module}.skip ; \
 			exit ; \
 		fi ; \
+		if [ `rpm --eval '0%{?suse_version}'` -gt 0 -a `rpm --eval '0%{?suse_version}'` -lt 1500 ]; then \
+			echo "Lua can't be build on SLES < 15 due to too old openssl" > \
+			nginx-module-$${module}.skip ; \
+			exit ; \
+		fi ; \
 		;; \
 		otel) \
 		if [ "`rpm --eval '0%{?suse_version}'`" -gt 0 ]; then \

--- a/rpm/SPECS/Makefile.module-lua
+++ b/rpm/SPECS/Makefile.module-lua
@@ -49,7 +49,8 @@ export MODULE_DEFINITIONS_lua
 
 define MODULE_PREBUILD_lua
 cd %{bdir}/luajit2-$(LUAJIT2_VERSION)
-DESTDIR="%{bdir}/luajit2-$(LUAJIT2_VERSION)" CFLAGS="-fPIC" make %{?_smp_mflags} install
+CFLAGS="-fPIC" make %{?_smp_mflags}
+DESTDIR="%{bdir}/luajit2-$(LUAJIT2_VERSION)" make install
 mv %{bdir}/luajit2-$(LUAJIT2_VERSION)/usr/bin/luajit %{bdir}/luajit2-$(LUAJIT2_VERSION)/usr/bin/nginx-luajit
 endef
 export MODULE_PREBUILD_lua


### PR DESCRIPTION
- Lua module on all OSes failed to find resty.core due to changes in Luajit2
- Lua failed to build on SLES 12 due to too old OpenSSL
- Thrift failed to build on Amazon Linux 2 due to failing patch