### PR TITLE
Respect custom configuration file locations

### DIFF
--- a/debian/debian/nginx-debug.default
+++ b/debian/debian/nginx-debug.default
@@ -1,8 +1,11 @@
-# Defaults for nginx initscript
+# Defaults for nginx-debug
 # sourced by /etc/init.d/nginx-debug
+# included by nginx-debug systemd service
 NAME="nginx-debug"
 DESC="nginx-debug"
 DAEMON="/usr/sbin/nginx-debug"
 
 # Additional options that are passed to nginx
 DAEMON_OPTS=""
+
+# CONFFILE="/etc/nginx/nginx.conf"

--- a/debian/debian/nginx-debug.service
+++ b/debian/debian/nginx-debug.service
@@ -7,7 +7,9 @@ Wants=network-online.target
 [Service]
 Type=forking
 PIDFile=/var/run/nginx.pid
-ExecStart=/usr/sbin/nginx-debug -c /etc/nginx/nginx.conf
+Environment="CONFFILE=/etc/nginx/nginx.conf"
+EnvironmentFile=-/etc/default/nginx-debug
+ExecStart=/usr/sbin/nginx-debug -c ${CONFFILE}
 ExecReload=/bin/sh -c "/bin/kill -s HUP $(/bin/cat /var/run/nginx.pid)"
 ExecStop=/bin/sh -c "/bin/kill -s TERM $(/bin/cat /var/run/nginx.pid)"
 

--- a/debian/debian/nginx.default
+++ b/debian/debian/nginx.default
@@ -1,5 +1,8 @@
-# Defaults for nginx initscript
+# Defaults for nginx
 # sourced by /etc/init.d/nginx
+# included by nginx systemd service
 
 # Additional options that are passed to nginx
 DAEMON_ARGS=""
+
+# CONFFILE="/etc/nginx/nginx.conf"

--- a/debian/debian/nginx.service
+++ b/debian/debian/nginx.service
@@ -7,7 +7,9 @@ Wants=network-online.target
 [Service]
 Type=forking
 PIDFile=/var/run/nginx.pid
-ExecStart=/usr/sbin/nginx -c /etc/nginx/nginx.conf
+Environment="CONFFILE=/etc/nginx/nginx.conf"
+EnvironmentFile=-/etc/default/nginx
+ExecStart=/usr/sbin/nginx -c ${CONFFILE}
 ExecReload=/bin/sh -c "/bin/kill -s HUP $(/bin/cat /var/run/nginx.pid)"
 ExecStop=/bin/sh -c "/bin/kill -s TERM $(/bin/cat /var/run/nginx.pid)"
 

--- a/rpm/SOURCES/nginx-debug.service
+++ b/rpm/SOURCES/nginx-debug.service
@@ -7,7 +7,9 @@ Wants=network-online.target
 [Service]
 Type=forking
 PIDFile=/var/run/nginx.pid
-ExecStart=/usr/sbin/nginx-debug -c /etc/nginx/nginx.conf
+Environment="conffile=/etc/nginx/nginx.conf"
+EnvironmentFile=-/etc/sysconfig/nginx
+ExecStart=/usr/sbin/nginx-debug -c ${conffile}
 ExecReload=/bin/sh -c "/bin/kill -s HUP $(/bin/cat /var/run/nginx.pid)"
 ExecStop=/bin/sh -c "/bin/kill -s TERM $(/bin/cat /var/run/nginx.pid)"
 

--- a/rpm/SOURCES/nginx.service
+++ b/rpm/SOURCES/nginx.service
@@ -7,7 +7,9 @@ Wants=network-online.target
 [Service]
 Type=forking
 PIDFile=/var/run/nginx.pid
-ExecStart=/usr/sbin/nginx -c /etc/nginx/nginx.conf
+Environment="conffile=/etc/nginx/nginx.conf"
+EnvironmentFile=-/etc/sysconfig/nginx
+ExecStart=/usr/sbin/nginx -c ${conffile}
 ExecReload=/bin/sh -c "/bin/kill -s HUP $(/bin/cat /var/run/nginx.pid)"
 ExecStop=/bin/sh -c "/bin/kill -s TERM $(/bin/cat /var/run/nginx.pid)"
 

--- a/rpm/SOURCES/nginx.upgrade.sh
+++ b/rpm/SOURCES/nginx.upgrade.sh
@@ -8,7 +8,7 @@ fi
 
 prog=nginx
 nginx=/usr/sbin/nginx
-conffile=/etc/nginx/nginx.conf
+conffile=${conffile:-/etc/nginx/nginx.conf}
 pidfile=`/usr/bin/systemctl show -p PIDFile nginx.service | sed 's/^PIDFile=//' | tr ' ' '\n'`
 SLEEPSEC=${SLEEPSEC:-1}
 UPGRADEWAITLOOPS=${UPGRADEWAITLOOPS:-5}


### PR DESCRIPTION
This allows administrator to redefine a custom location for a configuration file to be used during upgrade and startup.

References: https://github.com/nginx/pkg-oss/issues/24