### PR TITLE
Fix variable names with modname in module Makefile

### DIFF
--- a/build_module.sh
+++ b/build_module.sh
@@ -424,24 +424,25 @@ placeholder for nginx-module-$MODULE_NAME license / copyrights
 __EOF__
 
 echo "$ME: INFO: Creating module Makefile"
+MODNAME_MAKEFILE=`echo $MODULE_NAME | tr '-' '_'`
 cat << __EOF__ > Makefile.module-$MODULE_NAME
 MODULES=$MODULE_NAME
 
 MODULE_PACKAGE_VENDOR=	Build Script <build.script@example.com>
 MODULE_PACKAGE_URL=	https://www.nginx.com/blog/compiling-dynamic-modules-nginx-plus/
 
-MODULE_SUMMARY_$MODULE_NAME=		$MODULE_NAME dynamic module
-MODULE_VERSION_$MODULE_NAME=		$MODULE_VERSION
-MODULE_RELEASE_$MODULE_NAME=		$MODULE_RELEASE
-MODULE_VERSION_PREFIX_$MODULE_NAME=	\$(MODULE_TARGET_PREFIX)
-MODULE_CONFARGS_$MODULE_NAME=		--add-dynamic-module=\$(MODSRC_PREFIX)$MODULE_NAME-$VERSION
-MODULE_SOURCES_$MODULE_NAME=		$MODULE_NAME-$VERSION.tar.gz
+MODULE_SUMMARY_$MODNAME_MAKEFILE=		$MODULE_NAME dynamic module
+MODULE_VERSION_$MODNAME_MAKEFILE=		$MODULE_VERSION
+MODULE_RELEASE_$MODNAME_MAKEFILE=		$MODULE_RELEASE
+MODULE_VERSION_PREFIX_$MODNAME_MAKEFILE=	\$(MODULE_TARGET_PREFIX)
+MODULE_CONFARGS_$MODNAME_MAKEFILE=		--add-dynamic-module=\$(MODSRC_PREFIX)$MODULE_NAME-$VERSION
+MODULE_SOURCES_$MODNAME_MAKEFILE=		$MODULE_NAME-$VERSION.tar.gz
 
-define MODULE_POST_$MODULE_NAME
+define MODULE_POST_$MODNAME_MAKEFILE
 cat <<BANNER
 ----------------------------------------------------------------------
 
-The \$(MODULE_SUMMARY_$MODULE_NAME) for nginx has been installed.
+The \$(MODULE_SUMMARY_$MODNAME_MAKEFILE) for nginx has been installed.
 To enable this module, add the following to /etc/nginx/nginx.conf
 and reload nginx:
 
@@ -450,7 +451,7 @@ and reload nginx:
 ----------------------------------------------------------------------
 BANNER
 endef
-export MODULE_POST_$MODULE_NAME
+export MODULE_POST_$MODNAME_MAKEFILE
 __EOF__
 
 cp Makefile.module-$MODULE_NAME $BUILD_DIR/pkg-oss/rpm/SPECS/


### PR DESCRIPTION
### Proposed changes

In Makefile.module-*, variable names should use underscores (_) instead of dashes (-) in module names.
This convention is followed in code such as alpine/Makefile:114 and debian/Makefile:116.
For example, the version variable for the headers-more module in Makefile.headers-more is defined as`MODULE_VERSION_headers_more`.

However, `build_module.sh` currently generates `Makefile.module-$MODULE_NAME` using the module name as-is in variable names, without converting dashes to underscores.
As a result, modules with dashes in their names cannot be built correctly.

This patch addresses the issue by ensuring that module names used in variable names have dashes replaced with underscores.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
