### PR TITLE
contrib: fix debian-otel build failure on loongarch64

### DIFF
--- a/contrib/src/abseil-cpp/36c4b7940b84cb809d5d6bf0bc513c9b23834711.patch
+++ b/contrib/src/abseil-cpp/36c4b7940b84cb809d5d6bf0bc513c9b23834711.patch
@@ -1,0 +1,22 @@
+From 36c4b7940b84cb809d5d6bf0bc513c9b23834711 Mon Sep 17 00:00:00 2001
+From: Ma Aiguo <maaiguo@uniontech.com>
+Date: Mon, 21 Feb 2022 21:04:57 +0800
+Subject: [PATCH] Fit for build on loong64 architecture
+
+---
+ absl/debugging/internal/examine_stack.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/absl/debugging/internal/examine_stack.cc b/absl/debugging/internal/examine_stack.cc
+index 589a3ef367d..2fbfea8e53f 100644
+--- a/absl/debugging/internal/examine_stack.cc
++++ b/absl/debugging/internal/examine_stack.cc
+@@ -82,6 +82,8 @@ void* GetProgramCounter(void* vuc) {
+       return reinterpret_cast<void*>(context->uc_mcontext.gregs[16]);
+ #elif defined(__e2k__)
+     return reinterpret_cast<void*>(context->uc_mcontext.cr0_hi);
++#elif defined(__loongarch__)
++    return reinterpret_cast<void*>(context->uc_mcontext.__pc);
+ #else
+ #error "Undefined Architecture."
+ #endif

--- a/contrib/src/abseil-cpp/Makefile
+++ b/contrib/src/abseil-cpp/Makefile
@@ -14,5 +14,6 @@ abseil-cpp: abseil-cpp-$(ABSEIL_VERSION).tar.gz .sum-abseil-cpp
 	$(UNPACK)
 	$(APPLY) $(SRC)/abseil-cpp/b957f0ccd00481cd4fd663d8320aa02ae0564f18.patch
 	$(APPLY) $(SRC)/abseil-cpp/4500c2fada4e952037c59bd65e8be1ba0b29f21e.patch
+	$(APPLY) $(SRC)/abseil-cpp/36c4b7940b84cb809d5d6bf0bc513c9b23834711.patch
 	$(MOVE)
 


### PR DESCRIPTION
### Proposed changes

This patch will allow nginx deb packages to build smoothly on loongarch64 platforms, as the older abseil-cpp is not well supported.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
