### PR TITLE
fix: Handle intermittent network errors

### DIFF
--- a/build_module.sh
+++ b/build_module.sh
@@ -277,7 +277,7 @@ else
 			;;
 		"zip")
 			echo "$ME: INFO Downloading module source"
-			wget -O $BUILD_DIR/module.zip $1
+			wget --retry-on-http-error=429,502,503,504 --retry-on-host-error --retry-connrefused --tries 3 -O $BUILD_DIR/module.zip $1
 			ARCHIVE_DIR=`zipinfo -1 $BUILD_DIR/module.zip | head -n 1 | cut -f1 -d/`
 			unzip $BUILD_DIR/module.zip -d $BUILD_DIR
 			mv $BUILD_DIR/$ARCHIVE_DIR $MODULE_DIR
@@ -285,7 +285,7 @@ else
 		*)
 			echo "$ME: INFO Downloading module source"
 			# Assume tarball of some kind
-			wget -O $BUILD_DIR/module.tgz $1
+			wget --retry-on-http-error=429,502,503,504 --retry-on-host-error --retry-connrefused --tries 3 -O $BUILD_DIR/module.tgz $1
 			ARCHIVE_DIR=`tar tfz $BUILD_DIR/module.tgz | head -n 1 | cut -f1 -d/`
 			cd $BUILD_DIR
 			tar xfz module.tgz


### PR DESCRIPTION
### Proposed changes

Intermittent network errors may happen when a module's source code is downloaded. That happened to me recently (an unexpected 502 from GitHub) which resulted in a missing module in my Docker image (that was partially my fault, as the build process should stop in case of any error).

This PR implements automatic retries for common transient network hiccups.

Here's how that's going to work in practice:

```console
$ wget --retry-on-http-error=429,502,503,504 --retry-on-host-error --retry-connrefused --tries 3 -O /tmp/out https://httpbingo.org/status/429
--2025-09-05 11:14:04--  https://httpbingo.org/status/429
Resolving httpbingo.org (httpbingo.org)... 66.241.125.232, 2a09:8280:1:7fcb:9efa:a365:aa2a:d036
Connecting to httpbingo.org (httpbingo.org)|66.241.125.232|:443... connected.
HTTP request sent, awaiting response... 429 Too Many Requests
Retrying.

--2025-09-05 11:14:05--  (try: 2)  https://httpbingo.org/status/429
Reusing existing connection to httpbingo.org:443.
HTTP request sent, awaiting response... 429 Too Many Requests
Retrying.

--2025-09-05 11:14:07--  (try: 3)  https://httpbingo.org/status/429
Reusing existing connection to httpbingo.org:443.
HTTP request sent, awaiting response... 429 Too Many Requests
Giving up.
```

As per `wget`'s documentation:

> Wget will use linear backoff, waiting 1 second after the first failure on a given file, then waiting 2 seconds after the second failure on that file, up to the maximum number of seconds you specify.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
