### PR TITLE
contrib: nginx-acme: respect source config.

### DIFF
--- a/contrib/src/nginx-acme/Makefile
+++ b/contrib/src/nginx-acme/Makefile
@@ -31,7 +31,7 @@ cargo_vendor_archive = \
 	mkdir $${TMP_DIR} ; \
 	tar xf "$1" -C $${TMP_DIR} ; \
 	cd $${TMP_DIR}/* ; \
-	$(CARGO) vendor --locked ; \
+	$(CARGO) vendor --locked --respect-source-config; \
 	name=$$(basename `pwd`)-vendor ; \
 	eval $(TAR_COMMAND) ; \
 	cd ../.. ; \


### PR DESCRIPTION
This allows cargo vendor to use configuration files to redirect requests to Artifactory when downloading dependencies.  Surprisingly this isnt a default like for e.g. cargo fetch.
