### PR TITLE
acme: generate full debuginfo for release builds

### DIFF
--- a/debian/Makefile.module-acme
+++ b/debian/Makefile.module-acme
@@ -21,6 +21,8 @@ MODULE_CONFARGS_acme=	--add-dynamic-module=$(MODSRC_PREFIX)nginx-acme-$(NGINX_AC
 MODULE_BUILD_DEPENDS_acme=,clang
 
 define MODULE_DEFINITIONS_acme
+export CARGO_PROFILE_RELEASE_DEBUG=true
+export CARGO_PROFILE_RELEASE_STRIP=none
 export NGX_ACME_STATE_PREFIX=/var/cache/nginx
 endef
 export MODULE_DEFINITIONS_acme

--- a/rpm/SPECS/Makefile.module-acme
+++ b/rpm/SPECS/Makefile.module-acme
@@ -30,6 +30,8 @@ define MODULE_ENV_acme
 export OPENSSL_LIB_DIR=/usr/lib64/
 export OPENSSL_INCLUDE_DIR=/usr/include/
 %endif
+export CARGO_PROFILE_RELEASE_DEBUG=true
+export CARGO_PROFILE_RELEASE_STRIP=none
 export NGX_ACME_STATE_PREFIX=/var/cache/nginx
 endef
 export MODULE_ENV_acme


### PR DESCRIPTION
cargo build --release defaults to -C debuginfo=0[1], which is really not helpful for debugging or getting sane backtraces.

Our packaging uses split debuginfo, so the change will not affect the binary packages or container sizes.

[1]: https://doc.rust-lang.org/cargo/reference/profiles.html#debug

***

Normally, this should be handled by the distribution packaging (e.g. `%build_rustflags` on Fedora). I forgot that we cannot use that existing infra, and was pleasantly surprised to find that there's no debuginfo while investigating https://github.com/nginx/nginx-acme/issues/140.

### AlmaLinux 10

```
% rpm -qlvp RPMS.orig/x86_64/nginx-module-acme-*.rpm
-rwxr-xr-x    1 root     root                  7638176 Feb  4 00:00 /usr/lib64/nginx/modules/ngx_http_acme_module-debug.so
-rwxr-xr-x    1 root     root                  1210928 Feb  4 00:00 /usr/lib64/nginx/modules/ngx_http_acme_module.so
-rw-r--r--    1 root     root                 32210680 Feb  4 00:00 /usr/lib/debug/usr/lib64/nginx/modules/ngx_http_acme_module-debug.so-1.29.5+0.3.1-1.el10.ngx.x86_64.debug
-rw-r--r--    1 root     root                  4547224 Feb  4 00:00 /usr/lib/debug/usr/lib64/nginx/modules/ngx_http_acme_module.so-1.29.5+0.3.1-1.el10.ngx.x86_64.debug

% rpm -qlvp RPMS/x86_64/nginx-module-acme-*.rpm
-rwxr-xr-x    1 root     root                  7638176 Feb  4 00:00 /usr/lib64/nginx/modules/ngx_http_acme_module-debug.so
-rwxr-xr-x    1 root     root                  1210968 Feb  4 00:00 /usr/lib64/nginx/modules/ngx_http_acme_module.so
-rw-r--r--    1 root     root                 31204904 Feb  4 00:00 /usr/lib/debug/usr/lib64/nginx/modules/ngx_http_acme_module-debug.so-1.29.5+0.3.1-1.el10.ngx.x86_64.debug
-rw-r--r--    1 root     root                 14508208 Feb  4 00:00 /usr/lib/debug/usr/lib64/nginx/modules/ngx_http_acme_module.so-1.29.5+0.3.1-1.el10.ngx.x86_64.debug
```

### Debian 13

```
% dpkg --contents (orig)
-rw-r--r-- root/root   7479336 2026-02-04 12:12 ./usr/lib/nginx/modules/ngx_http_acme_module-debug.so
-rw-r--r-- root/root   1215944 2026-02-04 12:12 ./usr/lib/nginx/modules/ngx_http_acme_module.so
-rw-r--r-- root/root   9889984 2026-02-04 12:12 ./usr/lib/debug/.build-id/4c/dc31998c17dcc8af3692ddd8fd8bcfad28a937.debug
-rw-r--r-- root/root   1297384 2026-02-04 12:12 ./usr/lib/debug/.build-id/fc/6332714c4d416153908d782e5217b4f8814482.debug

% dpkg --contents (RUSTFLAGS)
-rw-r--r-- root/root   7479336 2026-02-04 12:12 ./usr/lib/nginx/modules/ngx_http_acme_module-debug.so
-rw-r--r-- root/root   1215944 2026-02-04 12:12 ./usr/lib/nginx/modules/ngx_http_acme_module.so
-rw-r--r-- root/root   3347352 2026-02-04 12:12 ./usr/lib/debug/.build-id/21/30d680a286d086414b91e9db4aaf522664c005.debug
-rw-r--r-- root/root   9889984 2026-02-04 12:12 ./usr/lib/debug/.build-id/4c/dc31998c17dcc8af3692ddd8fd8bcfad28a937.debug
```
### Alpine
```
$ grep CARGO_PROFILE /usr/bin/abuild
        export CARGO_PROFILE_RELEASE_DEBUG=true
        export CARGO_PROFILE_RELEASE_STRIP=none
```
