### PR TITLE
Pin action versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Setup Alpine Linux
-        uses: jirutka/setup-alpine@v1
+        uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 #v1
         with:
           branch: v3.20
           packages: >
@@ -114,7 +114,7 @@ jobs:
             xsltproc
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 #v1
         with:
           toolchain: 1.86.0
 
@@ -160,7 +160,7 @@ jobs:
           dnf config-manager --set-enabled crb
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 #v1
         with:
           toolchain: 1.86.0
 


### PR DESCRIPTION
Dependency pinning in CI workflow.
The same versions

* Updated the `jirutka/setup-alpine` action to use a specific commit SHA instead of a floating version in `.github/workflows/ci.yml`.
* Updated the `actions-rust-lang/setup-rust-toolchain` action to use a specific commit SHA in two places within `.github/workflows/ci.yml`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL117-R117) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL163-R163)