### PR TITLE
otel: propagate optimization flags to dependencies builds

### DIFF
--- a/debian/Makefile.module-otel
+++ b/debian/Makefile.module-otel
@@ -66,7 +66,7 @@ define MODULE_PREBUILD_otel
 		../cmake/ \&\& \
 	make -j$$(NUMJOBS) install \&\& \
 	cd $$(BUILDDIR_nginx)/extra/grpc-$(GRPC_VERSION) \&\& mkdir build \&\& cd build \&\& \
-	CXXFLAGS='-Wno-error=format-security -DGRPC_NO_XDS -DGRPC_NO_RLS' \
+	CXXFLAGS="$$(CXXFLAGS) -Wno-error=format-security -DGRPC_NO_XDS -DGRPC_NO_RLS" \
 		cmake \
 		-DCMAKE_CXX_STANDARD=17 \
 		-DCMAKE_CXX_EXTENSIONS=OFF \

--- a/rpm/SPECS/Makefile.module-otel
+++ b/rpm/SPECS/Makefile.module-otel
@@ -45,6 +45,10 @@ if [ $$_nproc -gt 1 ]; then
 	_make_opts="-j$$_nproc"
 fi
 
+export CFLAGS="%{optflags}"
+export CXXFLAGS="%{optflags}"
+export LDFLAGS="%{build_ldflags}"
+
 cd %{bdir} \&\& mkdir prebuilt
 %if ! 0%{defined suse_version}
 cd %{bdir}/abseil-cpp-$(ABSEIL_CPP_VERSION) \&\& mkdir build \&\& cd build \&\& \
@@ -77,7 +81,7 @@ cd %{bdir}/protobuf-$(PROTOBUF_VERSION) \&\& mkdir build \&\& cd build \&\& \
 	../cmake/ \&\& \
 	make $$_make_opts install \&\& \
 cd %{bdir}/grpc-$(GRPC_VERSION) \&\& mkdir build \&\& cd build \&\& \
-	CXXFLAGS='-DGRPC_NO_XDS -DGRPC_NO_RLS' \
+	CXXFLAGS="%{optflags} -DGRPC_NO_XDS -DGRPC_NO_RLS" \
 	cmake \
 	-DCMAKE_CXX_STANDARD=17 \
 	-DCMAKE_CXX_EXTENSIONS=OFF \


### PR DESCRIPTION
### Proposed changes

This PR makes sure the compiler/linker flags are propagated to otel deps builds.

Alpine does not need such a change cause we use OS-level dependencies.