### PR TITLE
Drop RELSTRING

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -29,11 +29,6 @@ MODSRC_PREFIX=	../
 
 NGINX_PLUS_MAJOR_MINOR = $(word 1,$(subst ., ,$(NGINX_PLUS_VERSION))).$(word 2,$(subst ., ,$(NGINX_PLUS_VERSION)))
 
-RELSTRING=
-ifeq ($(shell test $(PLUS_RELEASE) -gt 1; echo $$?),0)
-RELSTRING=-p$(shell expr $(PLUS_RELEASE) - 1 )
-endif
-
 BUILD_SUFFIX ?=
 
 ifeq ($(MODULE_TARGET), oss)
@@ -105,7 +100,7 @@ BASE_CONFIGURE_ARGS=\
 
 ifneq ($(BASE_TARGET), oss)
 BASE_CONFIGURE_ARGS+=\
-	--build=nginx-$(BASE_TARGET)-r$(PLUS_VERSION)$(RELSTRING)$(BUILD_SUFFIX) \
+	--build=nginx-$(BASE_TARGET)-r$(PLUS_VERSION)$(BUILD_SUFFIX) \
 	--state-path=/var/lib/nginx/state \
 	--with-control-api \
 	--with-http_auth_jwt_module \

--- a/debian/Makefile
+++ b/debian/Makefile
@@ -27,11 +27,6 @@ BUILD_ENV_PATH=	${HOME}/debuild
 
 NGINX_PLUS_MAJOR_MINOR = $(word 1,$(subst ., ,$(NGINX_PLUS_VERSION))).$(word 2,$(subst ., ,$(NGINX_PLUS_VERSION)))
 
-RELSTRING=
-ifeq ($(shell test $(PLUS_RELEASE) -gt 1; echo $$?),0)
-RELSTRING=-p$(shell expr $(PLUS_RELEASE) - 1 )
-endif
-
 BUILD_SUFFIX ?=
 
 ifeq ($(MODULE_TARGET), plus)
@@ -108,7 +103,7 @@ BASE_CONFIGURE_ARGS=\
 
 ifeq ($(BASE_TARGET), plus)
 BASE_CONFIGURE_ARGS+= \
-	--build=nginx-plus-r$(PLUS_VERSION)$(RELSTRING)$(BUILD_SUFFIX) \
+	--build=nginx-plus-r$(PLUS_VERSION)$(BUILD_SUFFIX) \
 	--state-path=/var/lib/nginx/state \
 	--with-control-api \
 	--with-http_auth_jwt_module \

--- a/rpm/SPECS/Makefile
+++ b/rpm/SPECS/Makefile
@@ -28,11 +28,6 @@ BUILD_DIR=	%{bdir}
 
 NGINX_PLUS_MAJOR_MINOR = $(word 1,$(subst ., ,$(NGINX_PLUS_VERSION))).$(word 2,$(subst ., ,$(NGINX_PLUS_VERSION)))
 
-RELSTRING=
-ifeq ($(shell test $(PLUS_RELEASE) -gt 1; echo $$?),0)
-RELSTRING=-p$(shell expr $(PLUS_RELEASE) - 1 )
-endif
-
 BUILD_SUFFIX ?=
 
 ifeq ($(MODULE_TARGET), plus)
@@ -109,7 +104,7 @@ fi; \
 
 ifeq ($(BASE_TARGET), plus)
 BASE_CONFIGURE_ARGS+= \
-	--build=nginx-plus-r$(PLUS_VERSION)$(RELSTRING)$(BUILD_SUFFIX) \
+	--build=nginx-plus-r$(PLUS_VERSION)$(BUILD_SUFFIX) \
 	--state-path=/var/lib/nginx/state \
 	--with-control-api \
 	--with-http_auth_jwt_module \


### PR DESCRIPTION
It's no longer required with the new NGINX Plus versioning scheme.
