### PR TITLE
CI: migrate off alpine action to a container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
   alpine:
     needs: generate-matrix
     runs-on: ubuntu-24.04
+    container: alpine:3.24
+    defaults:
+      run:
+        shell: sh -e {0}
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix-alpine)}}
@@ -49,44 +53,42 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Setup Alpine Linux
-        uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 #v1
-        with:
-          branch: v3.20
-          packages: >
-            abuild
-            build-base
-            coreutils
-            curl
-            findutils
-            git
-            make
-            rustup
+        run: |
+          apk add \
+            abuild \
+            bash \
+            build-base \
+            coreutils \
+            curl \
+            findutils \
+            git \
+            make \
+            rustup \
             xz
+          printf "#!/bin/sh\\nSETFATTR=true /usr/bin/abuild -F \"\$@\"\\n" > /usr/local/bin/abuild
+          chmod +x /usr/local/bin/abuild
 
       - name: Install Rust toolchain
-        shell: alpine.sh {0}
-        run: rustup-init --default-toolchain 1.86.0 --profile minimal -y
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 #v1
+        with:
+          toolchain: 1.86.0
 
       - name: Create build depends
-        shell: alpine.sh {0}
         working-directory: alpine
         run: |
           make abuild-${{ matrix.target }}
 
       - name: Install build depends
-        shell: alpine.sh --root {0}
         working-directory: alpine
         run: |
           apk add $(. ./abuild-${{ matrix.target }}/APKBUILD; echo $makedepends;)
 
       - name: Build ${{ matrix.target }}
-        shell: alpine.sh {0}
         working-directory: alpine
         run: |
           make ${{ matrix.target }}
 
       - name: List what has been built
-        shell: alpine.sh {0}
         if: ${{ !cancelled() }}
         run: |
           find ~/packages/alpine -type f | xargs ls -ld

--- a/alpine/Makefile.module-passenger
+++ b/alpine/Makefile.module-passenger
@@ -20,7 +20,7 @@ MODULE_CONFARGS_passenger=	--add-dynamic-module=$(MODSRC_PREFIX)passenger-$(PASS
 
 prerequisites-for-module-passenger:
 
-MODULE_BUILD_DEPENDS_passenger=ruby-dev ruby-rake ruby-etc
+MODULE_BUILD_DEPENDS_passenger=ruby-dev ruby-rake
 
 define MODULE_POST_passenger
 cat <<BANNER


### PR DESCRIPTION
### Proposed changes

This PR migrates the CI from alpine-setup action that fails a lot lately to a more error-prone approach with using a container.

While at it, fix an actual requires bug for Passenger.